### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "knex": "^0.16.3",
     "lodash": "^4.17.11",
     "nodemon": "^1.18.10",
-    "npm": "^6.8.0",
     "objection": "^1.6.3",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",


### PR DESCRIPTION

Hello 4arodey!

It seems like you have npm as one of your (dev-) dependency in ser.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
